### PR TITLE
Enable plotting of only single transfer function type with PlotTF

### DIFF
--- a/R/plotting.R
+++ b/R/plotting.R
@@ -631,7 +631,7 @@ PlotStackCorrelation <- function(data, col.pal = NULL, label = "",
 #' Plot transfer functions
 #'
 #' Plot the spectral transfer functions of the effects of diffusion and/or time
-#' uncertainty (e.g., as in the analysis of Münch and Laepple, 2018, Fig. B1).
+#' uncertainty.
 #'
 #' You can plot only diffusion transfer functions by supplying the respective
 #' data to the \code{dtf} parameter and leaving the \code{ttf} parameter as
@@ -644,11 +644,11 @@ PlotStackCorrelation <- function(data, col.pal = NULL, label = "",
 #' package, which corresponds to Figure B1 in Münch and Laepple (2018).
 #'
 #' @param dtf A list of transfer function data sets: each data set is an object
-#'   of class \code{"spec"} (see \code{?spectrum}) with minimum components
-#'   \code{freq} and \code{spec}, or simply a named list with these two, where
-#'   component \code{freq} is a numeric vector providing a frequency axis and
-#'   component \code{spec} a numeric vector with the corresponding diffusion
-#'   transfer function values. See Details for the meaning of \code{NULL}.
+#'   of class \code{"spec"} (see \code{?spectrum}) or a named list with minimum
+#'   components \code{freq} and \code{spec}, where component \code{freq} is a
+#'   numeric vector providing a frequency axis and component \code{spec} a
+#'   numeric vector with the corresponding diffusion transfer function
+#'   values. See Details for the meaning of \code{NULL}.
 #' @param ttf As \code{dtf} but providing time uncertainty transfer
 #'   functions. See Details for the meaning of \code{NULL}.
 #' @param names an optional character vector of names for the transfer function
@@ -845,7 +845,7 @@ PlotTF <- function(dtf = NULL, ttf = NULL,
                         cex.main = 1.5, cex.lab = 1.5, cex.axis = 1.25)
     on.exit(graphics::par(op))
 
-    plot.legend <- length(dtf) != length(ttf)
+    plot.legend <- is.list(names) | length(dtf) != length(ttf)
 
     .plottf(dtf, col = col, xlab = xlab, ylab = ylab1,
             xlim = xlim, ylim = ylim1, xtm = xtm, ytm = ytm1,

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -630,25 +630,33 @@ PlotStackCorrelation <- function(data, col.pal = NULL, label = "",
 
 #' Plot transfer functions
 #'
-#' Plot the spectral transfer functions of the effects of diffusion and time
+#' Plot the spectral transfer functions of the effects of diffusion and/or time
 #' uncertainty (e.g., as in the analysis of Münch and Laepple, 2018, Fig. B1).
+#'
+#' You can plot only diffusion transfer functions by supplying the respective
+#' data to the \code{dtf} parameter and leaving the \code{ttf} parameter as
+#' \code{NULL}, or vice versa for plotting only time uncertainty transfer
+#' functions. Supplying both parameters will plot the supplied diffusion as well
+#' as time uncertainty transfer functions (which can differ in number) on a
+#' single plot with a shared x axis. Leaving both the \code{dtf} and \code{ttf}
+#' parameters as \code{NULL} (the default) will plot the diffusion and time
+#' uncertainty transfer functions that are provided with the \code{proxysnr}
+#' package, which corresponds to Figure B1 in Münch and Laepple (2018).
 #'
 #' @param dtf A list of transfer function data sets: each data set is an object
 #'   of class \code{"spec"} (see \code{?spectrum}) with minimum components
 #'   \code{freq} and \code{spec}, or simply a named list with these two, where
 #'   component \code{freq} is a numeric vector providing a frequency axis and
 #'   component \code{spec} a numeric vector with the corresponding diffusion
-#'   transfer function values. If \code{NULL} (the default), the diffusion
-#'   transfer functions provided with the package are plotted, which corresponds
-#'   to Figure B1 in Münch and Laepple (2018).
+#'   transfer function values. See Details for the meaning of \code{NULL}.
 #' @param ttf As \code{dtf} but providing time uncertainty transfer
-#'   functions. If \code{NULL} (the default), the time uncertainty transfer
-#'   functions provided with the package are plotted, which corresponds to
-#'   Figure B1 in Münch and Laepple (2018).
+#'   functions. See Details for the meaning of \code{NULL}.
 #' @param names an optional character vector of names for the transfer function
 #'   data sets. If \code{NULL}, the names of \code{dtf} and \code{ttf} are used
-#'   or, if not present, default names. If the diffusion and time uncertainty
-#'   data sets differ in number, provide a list of two vectors of names.
+#'   or, if not present, default names. Provide a list of two vectors of names,
+#'   if the diffusion and time uncertainty data sets differ in number, or, if
+#'   they do **not** differ in number but belong to different underlying
+#'   datasets.
 #' @param col a numeric or character vector of colors to use for the plotting;
 #'   if \code{NULL} default colors are used.
 #' @param dtf.threshold optional critical diffusion transfer function

--- a/man/PlotTF.Rd
+++ b/man/PlotTF.Rd
@@ -30,19 +30,17 @@ of class \code{"spec"} (see \code{?spectrum}) with minimum components
 \code{freq} and \code{spec}, or simply a named list with these two, where
 component \code{freq} is a numeric vector providing a frequency axis and
 component \code{spec} a numeric vector with the corresponding diffusion
-transfer function values. If \code{NULL} (the default), the diffusion
-transfer functions provided with the package are plotted, which corresponds
-to Figure B1 in Münch and Laepple (2018).}
+transfer function values. See Details for the meaning of \code{NULL}.}
 
 \item{ttf}{As \code{dtf} but providing time uncertainty transfer
-functions. If \code{NULL} (the default), the time uncertainty transfer
-functions provided with the package are plotted, which corresponds to
-Figure B1 in Münch and Laepple (2018).}
+functions. See Details for the meaning of \code{NULL}.}
 
 \item{names}{an optional character vector of names for the transfer function
 data sets. If \code{NULL}, the names of \code{dtf} and \code{ttf} are used
-or, if not present, default names. If the diffusion and time uncertainty
-data sets differ in number, provide a list of two vectors of names.}
+or, if not present, default names. Provide a list of two vectors of names,
+if the diffusion and time uncertainty data sets differ in number, or, if
+they do **not** differ in number but belong to different underlying
+datasets.}
 
 \item{col}{a numeric or character vector of colors to use for the plotting;
 if \code{NULL} default colors are used.}
@@ -87,8 +85,19 @@ vector of labels of the same length as \code{ytm1}.}
 function plot.}
 }
 \description{
-Plot the spectral transfer functions of the effects of diffusion and time
+Plot the spectral transfer functions of the effects of diffusion and/or time
 uncertainty (e.g., as in the analysis of Münch and Laepple, 2018, Fig. B1).
+}
+\details{
+You can plot only diffusion transfer functions by supplying the respective
+data to the \code{dtf} parameter and leaving the \code{ttf} parameter as
+\code{NULL}, or vice versa for plotting only time uncertainty transfer
+functions. Supplying both parameters will plot the supplied diffusion as well
+as time uncertainty transfer functions (which can differ in number) on a
+single plot with a shared x axis. Leaving both the \code{dtf} and \code{ttf}
+parameters as \code{NULL} (the default) will plot the diffusion and time
+uncertainty transfer functions that are provided with the \code{proxysnr}
+package, which corresponds to Figure B1 in Münch and Laepple (2018).
 }
 \examples{
 

--- a/man/PlotTF.Rd
+++ b/man/PlotTF.Rd
@@ -26,11 +26,11 @@ PlotTF(
 }
 \arguments{
 \item{dtf}{A list of transfer function data sets: each data set is an object
-of class \code{"spec"} (see \code{?spectrum}) with minimum components
-\code{freq} and \code{spec}, or simply a named list with these two, where
-component \code{freq} is a numeric vector providing a frequency axis and
-component \code{spec} a numeric vector with the corresponding diffusion
-transfer function values. See Details for the meaning of \code{NULL}.}
+of class \code{"spec"} (see \code{?spectrum}) or a named list with minimum
+components \code{freq} and \code{spec}, where component \code{freq} is a
+numeric vector providing a frequency axis and component \code{spec} a
+numeric vector with the corresponding diffusion transfer function
+values. See Details for the meaning of \code{NULL}.}
 
 \item{ttf}{As \code{dtf} but providing time uncertainty transfer
 functions. See Details for the meaning of \code{NULL}.}
@@ -86,7 +86,7 @@ function plot.}
 }
 \description{
 Plot the spectral transfer functions of the effects of diffusion and/or time
-uncertainty (e.g., as in the analysis of Münch and Laepple, 2018, Fig. B1).
+uncertainty.
 }
 \details{
 You can plot only diffusion transfer functions by supplying the respective

--- a/tests/testthat/test-plotting.R
+++ b/tests/testthat/test-plotting.R
@@ -166,7 +166,8 @@ test_that("plotting tranfer functions works", {
   expect_no_error(PlotTF())
 
   # plot different number of datasets
-  expect_no_error(PlotTF(dtf = diffusion.tf["dml1"]))
+  expect_no_error(PlotTF(dtf = diffusion.tf["dml1"],
+                         ttf = time.uncertainty.tf[c("dml1", "wais")]))
 
   # plot with diffusion correction threshold
   expect_no_error(PlotTF(dtf.threshold = 0.67))
@@ -186,13 +187,18 @@ test_that("plotting tranfer functions works", {
   )
 
   # name number mismatch
-  msg <- "ttf: Number of data sets does not match number of names."
-  expect_warning(PlotTF(dtf = diffusion.tf["dml1"], names = "dml1"),
-                 msg, fixed = TRUE)
-  msg <- "dtf: Number of data sets does not match number of names."
-  expect_warning(PlotTF(dtf = diffusion.tf["dml1"],
-                        names = list(c("spock", "sybok"),
-                                     c("dml1", "dml2", "wais"))),
-                 msg, fixed = TRUE)
+  msg1 <- "dtf: Number of data sets does not match number of names."
+  expect_warning(PlotTF(dtf = diffusion.tf["dml1"], names = c("dml1", "wais")),
+                 msg1, fixed = TRUE)
+  msg2 <- "ttf: Number of data sets does not match number of names."
+  expect_warning(PlotTF(ttf = time.uncertainty.tf,
+                        names = c("spock", "sybok")),
+                 msg2, fixed = TRUE)
+  expect_warning(
+    expect_warning(
+      PlotTF(dtf = diffusion.tf["dml1"], ttf = time.uncertainty.tf,
+             names = list(c("spock", "sybok"), c("dml1"))),
+      msg1, fixed = TRUE),
+    msg2, fixed = TRUE)
 
 })

--- a/tests/testthat/test-plotting.R
+++ b/tests/testthat/test-plotting.R
@@ -186,6 +186,13 @@ test_that("plotting tranfer functions works", {
            names = list("bla", c("bloo", "blawp")))
   )
 
+  # same number of datasets but names supplied as list -> still plot two legends
+  expect_no_error(
+    PlotTF(dtf = diffusion.tf[c("dml1", "wais")],
+           ttf = time.uncertainty.tf[c("dml2", "wais")],
+           names = list(c("Site A", "Site B"), c("Site C", "Site B")))
+  )
+
   # name number mismatch
   msg1 <- "dtf: Number of data sets does not match number of names."
   expect_warning(PlotTF(dtf = diffusion.tf["dml1"], names = c("dml1", "wais")),


### PR DESCRIPTION
`PLotTF()` can now also be used to plot either only diffusion transfer functions or only time uncertainty transfer functions. This is more consistent then before behaviour which used the respective package transfer function data in the case when only one transfer function type was left NULL in the input. The default behaviour of plotting the package data when both input parameters are NULL is however kept. Function documentation and error checking was updated/enhanced respectively, as well as the handling of dataset names.