### PR TITLE
Add correction for measurement noise

### DIFF
--- a/R/SeparateSignalFromNoise.R
+++ b/R/SeparateSignalFromNoise.R
@@ -24,7 +24,13 @@
 #' @param neff the effective number of records (e.g. to account for an expected
 #'   spatial correlation of the local noise). Per default set to element
 #'   \code{N} in \code{spectra}, otherwise supply it explicitly here.
-#' @param measurement.noise 
+#' @param measurement.noise a measurement noise level for correcting the proxy
+#'   noise spectrum: either a single value or a spectral object. In the former
+#'   case, the value is used as the total variance of the measurement noise,
+#'   i.e. the level of an assumed white measurement noise spectrum; the latter
+#'   case can be applied if the measurement noise has a different spectral shape
+#'   (but its frequency range must then cover the frequency range of the proxy
+#'   spectra). The default `NULL` assumes no measurement noise.
 #' @param diffusion a spectral object of a transfer function desribing a
 #'   diffusion-like proxy smoothing process (see Details), e.g. diffusion in ice
 #'   cores (see also \code{\link{CalculateDiffusionTF}}). Internally, the

--- a/R/SeparateSignalFromNoise.R
+++ b/R/SeparateSignalFromNoise.R
@@ -96,7 +96,7 @@ SeparateSignalFromNoise <- function(spectra, neff = spectra$N,
              call. = FALSE)
     }
 
-    mns <- measurement.noise
+    mns <- c(measurement.noise)
 
   } else {
 
@@ -106,7 +106,7 @@ SeparateSignalFromNoise <- function(spectra, neff = spectra$N,
       measurement.noise <- InterpolateSpectrum(measurement.noise, spectra$mean)
     } else {
       stop("No sufficient frequency axis overlap between proxy data ",
-           "and measurement noise.", call. = FALSE)
+           "and measurement noise spectrum.", call. = FALSE)
     }
 
     mns <- measurement.noise$spec

--- a/man/SeparateSignalFromNoise.Rd
+++ b/man/SeparateSignalFromNoise.Rd
@@ -7,6 +7,7 @@
 SeparateSignalFromNoise(
   spectra,
   neff = spectra$N,
+  measurement.noise = NULL,
   diffusion = NULL,
   time.uncertainty = NULL
 )
@@ -21,6 +22,14 @@ the spectrum of the record stacked across the `n` records.}
 \item{neff}{the effective number of records (e.g. to account for an expected
 spatial correlation of the local noise). Per default set to element
 \code{N} in \code{spectra}, otherwise supply it explicitly here.}
+
+\item{measurement.noise}{a measurement noise level for correcting the proxy
+noise spectrum: either a single value or a spectral object. In the former
+case, the value is used as the total variance of the measurement noise,
+i.e. the level of an assumed white measurement noise spectrum; the latter
+case can be applied if the measurement noise has a different spectral shape
+(but its frequency range must then cover the frequency range of the proxy
+spectra). The default `NULL` assumes no measurement noise.}
 
 \item{diffusion}{a spectral object of a transfer function desribing a
 diffusion-like proxy smoothing process (see Details), e.g. diffusion in ice

--- a/tests/testthat/test-SeparateSignalFromNoise.R
+++ b/tests/testthat/test-SeparateSignalFromNoise.R
@@ -1,5 +1,7 @@
 test_that("SeparateSignalFromNoise error checks work", {
 
+  # --- test main input checks -------------------------------------------------
+
   m <- "`spectra` must be a list."
   expect_error(SeparateSignalFromNoise(1), m, fixed = TRUE)
 
@@ -31,6 +33,8 @@ test_that("SeparateSignalFromNoise error checks work", {
   expect_error(SeparateSignalFromNoise(list(mean = mean, stack = stack)),
                m, fixed = TRUE)
 
+  # --- test input checks related to measurement noise -------------------------
+
   m <- paste("`measurement.noise` must be a single value or a spectral object.")
   measurement.noise <- rnorm(3)
   expect_error(SeparateSignalFromNoise(list(mean = mean, stack = stack, N = 1),
@@ -56,6 +60,8 @@ test_that("SeparateSignalFromNoise error checks work", {
   expect_error(SeparateSignalFromNoise(list(mean = mean, stack = stack, N = 1),
                                        measurement.noise = measurement.noise),
                m, fixed = TRUE)
+
+  # --- test input checks related to transfer functions ------------------------
 
   m <- paste("`diffusion` must be a list with elements",
              "`freq` and `spec` of equal length.")
@@ -84,6 +90,8 @@ test_that("SeparateSignalFromNoise error checks work", {
 
 test_that("SeparateSignalFromNoise calculations work", {
 
+  # --- test default behaviour -------------------------------------------------
+
   signal <- list(freq = 1 : 10, spec = 1 : 10)
   noise <- list(freq = 1 : 10, spec = rep(5, 10))
   snr <- list(freq = 1 : 10, spec = signal$spec / noise$spec)
@@ -99,13 +107,13 @@ test_that("SeparateSignalFromNoise calculations work", {
 
   expect_equal(actual, expected)
 
-  # test deprecated function name
+  # --- test deprecated function name ------------------------------------------
 
   expect_warning(actual <- SeparateSpectra(spectra = list(mean = mean, stack = stack),
                                            neff = n))
   expect_equal(actual, expected)
 
-  # with diffusion and time uncertainty correction and N included in input
+  # --- test including N and transfer function input ---------------------------
 
   diff <- list(freq = signal$freq, spec = rep(1 / 1.5, length(signal$freq)))
   tunc <- list(freq = signal$freq, spec = rep(1 / 1.1, length(signal$freq)))
@@ -123,7 +131,7 @@ test_that("SeparateSignalFromNoise calculations work", {
 
   expect_equal(actual, expected)
 
-  # test interpolation of transfer functions
+  # --- test interpolation of transfer functions -------------------------------
 
   data <- ObtainArraySpectra(dml$dml2)
 
@@ -156,7 +164,9 @@ test_that("SeparateSignalFromNoise calculations work", {
 
   expect_no_error(SeparateSignalFromNoise(data, diffusion = tf))
 
-  # test with white measurement noise as a single value
+  # --- test measurement noise input -------------------------------------------
+
+  # white measurement noise as a single value
 
   signal <- list(freq = 1 : 10, spec = 1 : 10)
   noise <- list(freq = 1 : 10, spec = rep(5, 10))
@@ -176,7 +186,7 @@ test_that("SeparateSignalFromNoise calculations work", {
 
   expect_equal(actual, expected)
 
-  # test with white measurement noise as a spectral object
+  # white measurement noise as a spectral object
 
   measurement_noise <- list(freq = c(0.5, 3, 8, 15), spec = rep(0.25, 4))
 

--- a/tests/testthat/test-SeparateSignalFromNoise.R
+++ b/tests/testthat/test-SeparateSignalFromNoise.R
@@ -31,6 +31,32 @@ test_that("SeparateSignalFromNoise error checks work", {
   expect_error(SeparateSignalFromNoise(list(mean = mean, stack = stack)),
                m, fixed = TRUE)
 
+  m <- paste("`measurement.noise` must be a single value or a spectral object.")
+  measurement.noise <- rnorm(3)
+  expect_error(SeparateSignalFromNoise(list(mean = mean, stack = stack, N = 1),
+                                       measurement.noise = measurement.noise),
+               m, fixed = TRUE)
+
+  # should also work with length-1 array
+  measurement.noise <- matrix(0.1, 1, 1)
+  expect_no_warning(SeparateSignalFromNoise(
+    list(mean = mean, stack = stack, N = 1),
+    measurement.noise = measurement.noise))
+
+  m <- paste("`measurement.noise` must be a list with elements",
+             "`freq` and `spec` of equal length.")
+  measurement.noise <- list(a = 1)
+  expect_error(SeparateSignalFromNoise(list(mean = mean, stack = stack, N = 1),
+                                       measurement.noise = measurement.noise),
+               m, fixed = TRUE)
+
+  m <- paste("No sufficient frequency axis overlap between proxy data",
+             "and measurement noise spectrum.")
+  measurement.noise <- list(freq = 0.5, spec = 0.1)
+  expect_error(SeparateSignalFromNoise(list(mean = mean, stack = stack, N = 1),
+                                       measurement.noise = measurement.noise),
+               m, fixed = TRUE)
+
   m <- paste("`diffusion` must be a list with elements",
              "`freq` and `spec` of equal length.")
   tf <- list(a = 1)
@@ -129,5 +155,34 @@ test_that("SeparateSignalFromNoise calculations work", {
                              res = 0.5)
 
   expect_no_error(SeparateSignalFromNoise(data, diffusion = tf))
-                             
+
+  # test with white measurement noise as a single value
+
+  signal <- list(freq = 1 : 10, spec = 1 : 10)
+  noise <- list(freq = 1 : 10, spec = rep(5, 10))
+  snr <- list(freq = 1 : 10, spec = signal$spec / noise$spec)
+  class(signal) <- class(noise) <- class(snr) <- "spec"
+
+  n <- 5
+  measurement_noise <- 0.25
+  mean <- list(freq = signal$freq,
+               spec = signal$spec + noise$spec + measurement_noise)
+  stack <- list(freq = signal$freq,
+                spec = signal$spec + noise$spec / n + measurement_noise / n)
+
+  actual <- SeparateSignalFromNoise(spectra = list(mean = mean, stack = stack),
+                                    neff = n, measurement.noise = measurement_noise)
+  expected <- list(signal = signal, noise = noise, snr = snr)
+
+  expect_equal(actual, expected)
+
+  # test with white measurement noise as a spectral object
+
+  measurement_noise <- list(freq = c(0.5, 3, 8, 15), spec = rep(0.25, 4))
+
+  actual <- SeparateSignalFromNoise(spectra = list(mean = mean, stack = stack),
+                                    neff = n, measurement.noise = measurement_noise)
+
+  expect_equal(actual, expected)
+
 })


### PR DESCRIPTION
This PR adds to `SeparateSignalFromNoise()` the new feature of accounting for measurement noise (if it's variance and/or spectral shape is known) in the estimation and correction of the proxy noise spectrum.