### PR TITLE
Use attribute of proxy record array parameters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ LazyData: true
 RoxygenNote: 7.2.3
 VignetteBuilder: knitr
 Imports:
+    checkmate (>= 2.3.2),
     fpCompare,
     magrittr,
     multitaper,

--- a/R/EstimateCI.R
+++ b/R/EstimateCI.R
@@ -56,20 +56,33 @@ EstimateCI <- function(spectra, f.start = NULL, f.end = NULL, nmc = 10,
 
   if (!is.list(spectra)) stop("`spectra` must be a list.", call. = FALSE)
 
-  if (!all(utils::hasName(spectra, c("signal", "noise"))))
-    stop("`spectra` must have elements `signal` and `noise`.", call. = FALSE)
+  if (!all(utils::hasName(spectra, c("N", "signal", "noise", "snr"))))
+    stop("`spectra` must have elements `N`, `signal`, `noise`, and `snr`.",
+         call. = FALSE)
 
   check.if.spectrum(spectra$signal)
   check.if.spectrum(spectra$noise)
+  check.if.spectrum(spectra$snr)
 
   if (length(spectra$signal$freq) != length(spectra$noise$freq)) {
     stop("`signal` and `noise` must have the same number of spectral estimates.",
+         call. = FALSE)
+  }
+  if (length(spectra$signal$freq) != length(spectra$snr$freq)) {
+    stop("`signal` and `snr` must have the same number of spectral estimates.",
          call. = FALSE)
   }
 
   if (!all(spectra$signal$freq == spectra$noise$freq)) {
     stop("Frequency axes of `signal` and `noise` do not match.", call. = FALSE)
   }
+  if (!all(spectra$signal$freq == spectra$snr$freq)) {
+    stop("Frequency axes of `signal` and `snr` do not match.", call. = FALSE)
+  }
+
+  if (!checkmate::testNumber(spectra$N, lower = 2, finite = TRUE))
+    stop("`spectra$N` must be a single integer > 1 supplying the number ",
+         "of records underlying the analyses in `spectra`.", call. = FALSE)
 
   # ----------------------------------------------------------------------------
   # helper functions

--- a/R/EstimateCI.R
+++ b/R/EstimateCI.R
@@ -16,9 +16,8 @@
 #' signal, noise, and SNR to yield the confidence intervals.
 #'
 #' @param spectra a list with the spectral objects `signal`, `noise`, and `snr`
-#'   from an investigated proxy record array for which to estimate confidence
-#'   intervals, together with the number of records, `N`, in the array; this
-#'   list is usually to be obtained from \code{\link{SeparateSignalFromNoise}}.
+#'   for an investigated proxy record array, obtained from
+#'   \code{\link{SeparateSignalFromNoise}}.
 #' @param f.start lower end of the frequency range on which the power-law fit is
 #'   made on the proxy data; the default \code{NULL} uses the lowest frequency
 #'   of the proxy \code{spectra}.
@@ -56,8 +55,8 @@ EstimateCI <- function(spectra, f.start = NULL, f.end = NULL, nmc = 10,
 
   if (!is.list(spectra)) stop("`spectra` must be a list.", call. = FALSE)
 
-  if (!all(utils::hasName(spectra, c("N", "signal", "noise", "snr"))))
-    stop("`spectra` must have elements `N`, `signal`, `noise`, and `snr`.",
+  if (!all(utils::hasName(spectra, c("signal", "noise", "snr"))))
+    stop("`spectra` must have elements `signal`, `noise`, and `snr`.",
          call. = FALSE)
 
   check.if.spectrum(spectra$signal)
@@ -80,9 +79,7 @@ EstimateCI <- function(spectra, f.start = NULL, f.end = NULL, nmc = 10,
     stop("Frequency axes of `signal` and `snr` do not match.", call. = FALSE)
   }
 
-  if (!checkmate::testNumber(spectra$N, lower = 2, finite = TRUE))
-    stop("`spectra$N` must be a single integer > 1 supplying the number ",
-         "of records underlying the analyses in `spectra`.", call. = FALSE)
+  has.array.attribute(spectra)
 
   # ----------------------------------------------------------------------------
   # helper functions
@@ -277,12 +274,12 @@ runSimulation <- function(spectra, f.start = NULL, f.end = NULL,
   signal.par <- fit.powerlaw(spectra$signal, f.start, f.end)
   noise.par  <- fit.powerlaw(spectra$noise, f.start, f.end)
 
-  # get time resolution of original proxy records
-  res <- 1 / (2 * max(spectra$signal$freq))
-  # get number of time steps
-  nt <- 1 / (res * spectra$signal$freq[1])
   # get number of cores underlying results in `spectra`
-  nc <- spectra$N
+  nc <- attr(spectra, "array.par")[["nc"]]
+  # get number of time steps of original proxy records
+  nt <- attr(spectra, "array.par")[["nt"]]
+  # get time resolution of original proxy records
+  res <- attr(spectra, "array.par")[["res"]]
 
   runSurrogates(signal.par = signal.par, noise.par = noise.par,
                 nc = nc, nt = nt, res = res, nmc = nmc,

--- a/R/ObtainArraySpectra.R
+++ b/R/ObtainArraySpectra.R
@@ -44,6 +44,9 @@ ObtainArraySpectra <- function(cores, res = 1, neff = length(cores),
   if (!is.list(cores))
     stop("`cores` must be a list or a data frame.", call. = FALSE)
 
+  if (length(cores) == 1)
+    stop("Only one proxy record (`cores` is of length 1).", call. = FALSE)
+
   if (!is.data.frame(cores)) {
 
     # data vectors in list must be of the same length

--- a/R/ObtainArraySpectra.R
+++ b/R/ObtainArraySpectra.R
@@ -22,14 +22,17 @@
 #'
 #' @return A list of the following components:
 #'   \describe{
-#'   \item{N:}{the number of (effective) proxy records of the core array;}
 #'   \item{single:}{a list of \code{N} spectral objects (`?spec.object`) with
 #'     the spectra of each individual proxy record;}
 #'   \item{mean:}{spectral object of the mean spectrum across all individual
 #'     spectra;}
 #'   \item{stack:}{spectral object of the spectrum of the average proxy record
-#'     in the time domain ("stacked record").}
+#'     in the time domain ("stacked record");}
 #' }
+#' with the attribute "array.par": a named vector with information on the proxy
+#' record array: number of (effective) records ("nc" = \code{neff}), number of
+#' observation points per record ("nt"), and sampling resolution ("res" =
+#' \code{res}).
 #'
 #' @author Thomas Münch
 #' @seealso \code{\link{PlotArraySpectra}}, \code{\link{SpecMTM}},
@@ -47,10 +50,11 @@ ObtainArraySpectra <- function(cores, res = 1, neff = length(cores),
   if (length(cores) == 1)
     stop("Only one proxy record (`cores` is of length 1).", call. = FALSE)
 
+  ll <- lengths(cores, use.names = FALSE)
   if (!is.data.frame(cores)) {
 
     # data vectors in list must be of the same length
-    if (stats::sd(lengths(cores)) > 0) {
+    if (stats::sd(ll) > 0) {
       stop("Elements of `cores` must all have the same length.", call. = FALSE)
     }
 
@@ -78,12 +82,18 @@ ObtainArraySpectra <- function(cores, res = 1, neff = length(cores),
     stack  <- LogSmooth(stack, df.log = df.log)
   }
 
-  # return results as a list
+  # return results as a list with attribute supplying the array parameter
+
+  setAttr <- function(x) {
+    attr(x, "array.par") <- c(nc = neff, nt = ll[1], res = res)
+    return(x)
+  }
+
   list(
-    N          = neff,
-    single     = single,
-    mean       = mean,
-    stack      = stack
-  )
+    single = single,
+    mean   = mean,
+    stack  = stack
+  ) %>%
+    setAttr()
 
 }

--- a/R/WrapSpectralResults.R
+++ b/R/WrapSpectralResults.R
@@ -31,13 +31,12 @@
 #'   0.5.
 #'
 #' @return A list of \code{n} lists, where \code{n} is the number of provided
-#'   data sets and where each of these lists contains up to five elements:
+#'   data sets and where each of these lists contains up to four elements:
 #'   \describe{
-#'   \item{\code{raw}:}{a list with five elements: the number of records
-#'     underlying the analysis (\code{N}), three spectral objects (the raw
-#'     signal, noise and corresponding SNR spectra), and a two-element vector
-#'     (\code{f.cutoff}) with the index and value of the cutoff frequency from
-#'     constraining the smoothing correction (see the \code{crit.diffusion}
+#'   \item{\code{raw}:}{a list with four elements: three spectral objects (the
+#'     raw signal, noise and corresponding SNR spectra), and a two-element
+#'     vector (\code{f.cutoff}) with the index and value of the cutoff frequency
+#'     from constraining the smoothing correction (see the \code{crit.diffusion}
 #'     parameter).}
 #'   \item{\code{corr.diff.only}:}{as item \code{raw} but with the spectra after
 #'     correction for the effect of diffusion-like smoothing.}
@@ -51,7 +50,7 @@
 #' whether transfer functions for the corrections have been provided in
 #' \code{diffusion} and \code{time.uncertainty} or not. Also, the element
 #' \code{f.cutoff} is `NA` if diffusion-like smoothing has not been corrected
-#'   for.
+#' for.
 #'
 #' @seealso \code{\link{SeparateSignalFromNoise}},
 #'   \code{\link{CalculateDiffusionTF}},

--- a/R/paper-plotting.R
+++ b/R/paper-plotting.R
@@ -124,6 +124,9 @@ PublicationSNR <- function(spec,
   res$wais$snr      <- wais.snr
   res$wais$f.cutoff <- spec.wais$f.cutoff
 
+  attr(res$dml, "array.par") <- attr(spec.dml2, "array.par") # use DML2 parameter
+  attr(res$wais, "array.par") <- attr(spec.wais, "array.par")
+
   return(res)
 
 }

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -130,9 +130,11 @@ PlotArraySpectra <- function(spec, marker = NA, remove = 1,
   if (!length(remove) %in% c(1, 2))
     stop("`remove` must be a single value or a length-2 vector.", call. = FALSE)
 
+  has.array.attribute(spec)
+
   # Gather input
   
-  N <- length(spec$single)    
+  N <- attr(spec, "array.par")[["nc"]]
   psd1 <- spec$mean
   psd2 <- spec$stack
   psd3 <- psd1

--- a/R/utils.R
+++ b/R/utils.R
@@ -210,3 +210,35 @@ InterpolateSpectrum <- function(x, target, num.prec = 8) {
 
 }
 
+has.array.attribute <- function(x) {
+
+  n <- sprintf(" `%s`.", deparse(substitute(x)))
+  a <- attributes(x)
+
+  if (length(a) == 0)
+    stop("Attribute `array.par` missing from input object", n, call. = FALSE)
+
+  if (length(a$array.par) == 0)
+    stop("Attribute `array.par` missing from input object", n, call. = FALSE)
+
+  if (!all(utils::hasName(a$array.par, c("nc", "nt", "res"))))
+    stop("Attribute `array.par` must a named vector with elements ",
+         "`nc`, `nt`, `res`.", call. = FALSE)
+
+  if (!checkmate::testNumber(a$array.par[["nc"]], lower = 2, finite = TRUE))
+    stop("Element `nc` of `array.par attribute ",
+         "(number of proxy records) ",
+         "must be a single integer >= 2.", call. = FALSE)
+
+  if (!checkmate::testNumber(a$array.par[["nt"]], lower = 9, finite = TRUE))
+    stop("Element `nt` of `array.par attribute ",
+         "(number of observations per proxy record) ",
+         "must be a single integer > 8.", call. = FALSE)
+
+  if (!checkmate::testNumber(a$array.par[["res"]], lower = 1e-15, finite = TRUE))
+    stop("Element `res` of `array.par attribute ",
+         "(resolution of proxy records) ",
+         "must be a single integer > 0.", call. = FALSE)
+
+}
+

--- a/man/EstimateCI.Rd
+++ b/man/EstimateCI.Rd
@@ -16,9 +16,8 @@ EstimateCI(
 }
 \arguments{
 \item{spectra}{a list with the spectral objects `signal`, `noise`, and `snr`
-from an investigated proxy record array for which to estimate confidence
-intervals, together with the number of records, `N`, in the array; this
-list is usually to be obtained from \code{\link{SeparateSignalFromNoise}}.}
+for an investigated proxy record array, obtained from
+\code{\link{SeparateSignalFromNoise}}.}
 
 \item{f.start}{lower end of the frequency range on which the power-law fit is
 made on the proxy data; the default \code{NULL} uses the lowest frequency

--- a/man/ObtainArraySpectra.Rd
+++ b/man/ObtainArraySpectra.Rd
@@ -29,14 +29,17 @@ function \code{\link{SpecMTM}}.}
 \value{
 A list of the following components:
   \describe{
-  \item{N:}{the number of (effective) proxy records of the core array;}
   \item{single:}{a list of \code{N} spectral objects (`?spec.object`) with
     the spectra of each individual proxy record;}
   \item{mean:}{spectral object of the mean spectrum across all individual
     spectra;}
   \item{stack:}{spectral object of the spectrum of the average proxy record
-    in the time domain ("stacked record").}
+    in the time domain ("stacked record");}
 }
+with the attribute "array.par": a named vector with information on the proxy
+record array: number of (effective) records ("nc" = \code{neff}), number of
+observation points per record ("nt"), and sampling resolution ("res" =
+\code{res}).
 }
 \description{
 Calculate all relevant spectral estimates for a given array of \code{n}

--- a/man/SeparateSignalFromNoise.Rd
+++ b/man/SeparateSignalFromNoise.Rd
@@ -6,22 +6,21 @@
 \usage{
 SeparateSignalFromNoise(
   spectra,
-  neff = spectra$N,
+  neff = NULL,
   measurement.noise = NULL,
   diffusion = NULL,
   time.uncertainty = NULL
 )
 }
 \arguments{
-\item{spectra}{a list of the spectral estimates from a proxy core array as
-output from \code{\link{ObtainArraySpectra}}, or, as minimum requirement, a
-named list (components `mean` and `stack` as spectral objects; see
-`?spec.object`) supplying the mean spectrum of the `n` proxy records and
-the spectrum of the record stacked across the `n` records.}
+\item{spectra}{a list of the spectral estimates from a proxy core array in
+the format as output from \code{\link{ObtainArraySpectra}}.}
 
-\item{neff}{the effective number of records (e.g. to account for an expected
-spatial correlation of the local noise). Per default set to element
-\code{N} in \code{spectra}, otherwise supply it explicitly here.}
+\item{neff}{the effective number of records (`neff` <= `n`, e.g. to account
+for an expected spatial correlation of the local noise). Per default
+extracted from the "array.par" attribute of `spectra` (see the "Value"
+section from \code{\link{?ObtainArraySpectra}}), but you can supply the
+`neff` explicitly here to overwrite the default value.}
 
 \item{measurement.noise}{a measurement noise level for correcting the proxy
 noise spectrum: either a single value or a spectral object. In the former
@@ -47,15 +46,16 @@ correct the effect it has on the estimated signal spectrum. The default
 `NULL` is to apply no correction.}
 }
 \value{
-A list of four objects: one integer value and three spectral objects:
+A list of three spectral objects:
   \describe{
-  \item{\code{N}:}{the (effective) number of records underlying the
-    analysis;}
   \item{\code{signal}:}{the raw or corrected signal spectrum;}
   \item{\code{noise}:}{the raw or corrected noise spectrum;}
   \item{\code{snr}:}{the signal-to-noise ratio as calculated from the previous
-    components.}
+    components;}
 }
+with the attribute "array.par": a named vector with information on the proxy
+record array: number of (effective) records ("nc" = \code{neff}), number of
+observation points per record ("nt"), and sampling resolution ("res").
 }
 \description{
 Calculate the raw signal and noise spectra and the corresponding

--- a/man/WrapSpectralResults.Rd
+++ b/man/WrapSpectralResults.Rd
@@ -44,13 +44,12 @@ large uncertainties at the high-frequency end of the spectra; defaults to
 }
 \value{
 A list of \code{n} lists, where \code{n} is the number of provided
-  data sets and where each of these lists contains up to five elements:
+  data sets and where each of these lists contains up to four elements:
   \describe{
-  \item{\code{raw}:}{a list with five elements: the number of records
-    underlying the analysis (\code{N}), three spectral objects (the raw
-    signal, noise and corresponding SNR spectra), and a two-element vector
-    (\code{f.cutoff}) with the index and value of the cutoff frequency from
-    constraining the smoothing correction (see the \code{crit.diffusion}
+  \item{\code{raw}:}{a list with four elements: three spectral objects (the
+    raw signal, noise and corresponding SNR spectra), and a two-element
+    vector (\code{f.cutoff}) with the index and value of the cutoff frequency
+    from constraining the smoothing correction (see the \code{crit.diffusion}
     parameter).}
   \item{\code{corr.diff.only}:}{as item \code{raw} but with the spectra after
     correction for the effect of diffusion-like smoothing.}
@@ -64,7 +63,7 @@ The number of the returned list elements for each data set depends on
 whether transfer functions for the corrections have been provided in
 \code{diffusion} and \code{time.uncertainty} or not. Also, the element
 \code{f.cutoff} is `NA` if diffusion-like smoothing has not been corrected
-  for.
+for.
 }
 \description{
 This wrapper function is used to combine all main spectral results for the

--- a/man/runSimulation.Rd
+++ b/man/runSimulation.Rd
@@ -8,9 +8,8 @@ runSimulation(spectra, f.start = NULL, f.end = NULL, nmc = 10, df.log = NULL)
 }
 \arguments{
 \item{spectra}{a list with the spectral objects `signal`, `noise`, and `snr`
-from an investigated proxy record array for which to estimate confidence
-intervals, together with the number of records, `N`, in the array; this
-list is usually to be obtained from \code{\link{SeparateSignalFromNoise}}.}
+for an investigated proxy record array, obtained from
+\code{\link{SeparateSignalFromNoise}}.}
 
 \item{f.start}{lower end of the frequency range on which the power-law fit is
 made on the proxy data; the default \code{NULL} uses the lowest frequency

--- a/tests/testthat/test-EstimateCI.R
+++ b/tests/testthat/test-EstimateCI.R
@@ -121,6 +121,90 @@ test_that("simulation produces correct frequency axis", {
 
 })
 
+test_that("CI error checks work", {
+
+  m <- "`spectra` must be a list."
+
+  expect_error(EstimateCI(1), m, fixed = TRUE)
+  expect_error(EstimateCI(matrix()), m, fixed = TRUE)
+
+  m <- "`spectra` must have elements `N`, `signal`, `noise`, and `snr`."
+
+  expect_error(EstimateCI(list()), m, fixed = TRUE)
+  expect_error(EstimateCI(list(N = 1)), m, fixed = TRUE)
+  expect_error(EstimateCI(list(N = 1, signal = list())), m, fixed = TRUE)
+  expect_error(EstimateCI(list(signal = list(), noise = list())),
+               m, fixed = TRUE)
+  expect_error(EstimateCI(list(N = 1, signal = list(), snr = list())),
+               m, fixed = TRUE)
+
+  s1 <- list(freq = 1, spec = 1)
+  s2 <- list(freq = 3 : 12, spec = rnorm(10))
+
+  m <- paste("`spectra$signal` must be a list with elements",
+             "`freq` and `spec` of equal length.")
+
+  expect_error(EstimateCI(
+    list(N = 1, signal = list(), noise = list(), snr = list())),
+    m, fixed = TRUE)
+
+  m <- paste("`spectra$snr` must be a list with elements",
+             "`freq` and `spec` of equal length.")
+
+  expect_error(EstimateCI(
+    list(N = 1, signal = s1, noise = s1, snr = list())),
+    m, fixed = TRUE)
+
+  m <- "`signal` and `noise` must have the same number of spectral estimates."
+
+  expect_error(EstimateCI(
+    list(N = 1, signal = s1, noise = s2, snr = s1)),
+    m, fixed = TRUE)
+
+  m <- "`signal` and `snr` must have the same number of spectral estimates."
+
+  expect_error(EstimateCI(
+    list(N = 1, signal = s1, noise = s1, snr = s2)),
+    m, fixed = TRUE)
+
+  s1 <- list(freq = 1 : 10, spec = rnorm(10))
+
+  m <- "Frequency axes of `signal` and `noise` do not match."
+
+  expect_error(EstimateCI(
+    list(N = 1, signal = s1, noise = s2, snr = s2)),
+    m, fixed = TRUE)
+
+  m <- "Frequency axes of `signal` and `snr` do not match."
+
+  expect_error(EstimateCI(
+    list(N = 1, signal = s1, noise = s1, snr = s2)),
+    m, fixed = TRUE)
+
+  m <- paste("`spectra$N` must be a single integer > 1 supplying the number",
+             "of records underlying the analyses in `spectra`.")
+
+  spectra <- list(signal = s1, noise = s1, snr = s1)
+
+  spectra$N <- 1 : 3
+  expect_error(EstimateCI(spectra), m, fixed = TRUE)
+  spectra$N <- -5
+  expect_error(EstimateCI(spectra), m, fixed = TRUE)
+  spectra$N <- 1
+  expect_error(EstimateCI(spectra), m, fixed = TRUE)
+  spectra$N <- list(N = 1)
+  expect_error(EstimateCI(spectra), m, fixed = TRUE)
+  spectra$N <- data.frame(N = 1)
+  expect_error(EstimateCI(spectra), m, fixed = TRUE)
+  spectra$N <- matrix(data = 1, ncol = 2)
+  expect_error(EstimateCI(spectra), m, fixed = TRUE)
+  spectra$N <- NA
+  expect_error(EstimateCI(spectra), m, fixed = TRUE)
+  spectra$N <- Inf
+  expect_error(EstimateCI(spectra), m, fixed = TRUE)
+
+})
+
 test_that("CI estimation works", {
 
   # test using DML2 dataset from Muench and Laepple (2018)

--- a/tests/testthat/test-EstimateCI.R
+++ b/tests/testthat/test-EstimateCI.R
@@ -21,8 +21,8 @@ test_that("simulated signal and noise spectra are valid", {
   sim <- simSignalAndNoise(signal.par, noise.par, nc = nc, nt = nt, res = 1)
 
   expect_type(sim, "list")
-  expect_length(sim, 4)
-  expect_named(sim, c("N", "signal", "noise", "snr"))
+  expect_length(sim, 3)
+  expect_named(sim, c("signal", "noise", "snr"))
 
   expect_true(is.spectrum(sim$signal))
   expect_true(is.spectrum(sim$noise))
@@ -37,7 +37,7 @@ test_that("running surrogate signal and noise spectra works", {
 
   expect_type(sim, "list")
   expect_length(sim, nmc)
-  expect_equal(lengths(sim), rep(4, nmc))
+  expect_equal(lengths(sim), rep(3, nmc))
 
 })
 
@@ -128,7 +128,7 @@ test_that("CI error checks work", {
   expect_error(EstimateCI(1), m, fixed = TRUE)
   expect_error(EstimateCI(matrix()), m, fixed = TRUE)
 
-  m <- "`spectra` must have elements `N`, `signal`, `noise`, and `snr`."
+  m <- "`spectra` must have elements `signal`, `noise`, and `snr`."
 
   expect_error(EstimateCI(list()), m, fixed = TRUE)
   expect_error(EstimateCI(list(N = 1)), m, fixed = TRUE)
@@ -145,26 +145,26 @@ test_that("CI error checks work", {
              "`freq` and `spec` of equal length.")
 
   expect_error(EstimateCI(
-    list(N = 1, signal = list(), noise = list(), snr = list())),
+    list(signal = list(), noise = list(), snr = list())),
     m, fixed = TRUE)
 
   m <- paste("`spectra$snr` must be a list with elements",
              "`freq` and `spec` of equal length.")
 
   expect_error(EstimateCI(
-    list(N = 1, signal = s1, noise = s1, snr = list())),
+    list(signal = s1, noise = s1, snr = list())),
     m, fixed = TRUE)
 
   m <- "`signal` and `noise` must have the same number of spectral estimates."
 
   expect_error(EstimateCI(
-    list(N = 1, signal = s1, noise = s2, snr = s1)),
+    list(signal = s1, noise = s2, snr = s1)),
     m, fixed = TRUE)
 
   m <- "`signal` and `snr` must have the same number of spectral estimates."
 
   expect_error(EstimateCI(
-    list(N = 1, signal = s1, noise = s1, snr = s2)),
+    list(signal = s1, noise = s1, snr = s2)),
     m, fixed = TRUE)
 
   s1 <- list(freq = 1 : 10, spec = rnorm(10))
@@ -172,36 +172,14 @@ test_that("CI error checks work", {
   m <- "Frequency axes of `signal` and `noise` do not match."
 
   expect_error(EstimateCI(
-    list(N = 1, signal = s1, noise = s2, snr = s2)),
+    list(signal = s1, noise = s2, snr = s2)),
     m, fixed = TRUE)
 
   m <- "Frequency axes of `signal` and `snr` do not match."
 
   expect_error(EstimateCI(
-    list(N = 1, signal = s1, noise = s1, snr = s2)),
+    list(signal = s1, noise = s1, snr = s2)),
     m, fixed = TRUE)
-
-  m <- paste("`spectra$N` must be a single integer > 1 supplying the number",
-             "of records underlying the analyses in `spectra`.")
-
-  spectra <- list(signal = s1, noise = s1, snr = s1)
-
-  spectra$N <- 1 : 3
-  expect_error(EstimateCI(spectra), m, fixed = TRUE)
-  spectra$N <- -5
-  expect_error(EstimateCI(spectra), m, fixed = TRUE)
-  spectra$N <- 1
-  expect_error(EstimateCI(spectra), m, fixed = TRUE)
-  spectra$N <- list(N = 1)
-  expect_error(EstimateCI(spectra), m, fixed = TRUE)
-  spectra$N <- data.frame(N = 1)
-  expect_error(EstimateCI(spectra), m, fixed = TRUE)
-  spectra$N <- matrix(data = 1, ncol = 2)
-  expect_error(EstimateCI(spectra), m, fixed = TRUE)
-  spectra$N <- NA
-  expect_error(EstimateCI(spectra), m, fixed = TRUE)
-  spectra$N <- Inf
-  expect_error(EstimateCI(spectra), m, fixed = TRUE)
 
 })
 
@@ -216,8 +194,8 @@ test_that("CI estimation works", {
                                 df.log = NULL, ci.df.log = NULL)
 
   expect_type(spectra.with.ci, "list")
-  expect_length(spectra.with.ci, 4)
-  expect_named(spectra.with.ci, c("N", "signal", "noise", "snr"))
+  expect_length(spectra.with.ci, 3)
+  expect_named(spectra.with.ci, c("signal", "noise", "snr"))
 
   nms <- c("freq", "spec", "lim.1", "lim.2")
 
@@ -250,17 +228,14 @@ test_that("CI estimation works", {
     proxysnr:::PublicationSNR(data = "raw") %>%
     .$dml
 
-  # supply number of records manually: use 3
-  spectra$N <- 3
-
   expect_warning(
     spectra.with.ci <- EstimateCI(spectra, f.end = 0.1,
                                   df.log = 0.15, ci.df.log = 0.05),
     w)
 
   expect_type(spectra.with.ci, "list")
-  expect_length(spectra.with.ci, 5)
-  expect_named(spectra.with.ci, c("signal", "noise", "snr", "f.cutoff", "N"))
+  expect_length(spectra.with.ci, 4)
+  expect_named(spectra.with.ci, c("signal", "noise", "snr", "f.cutoff"))
   expect_equal(spectra.with.ci$N, spectra$N)
 
   nms <- c("freq", "spec", "lim.1", "lim.2")

--- a/tests/testthat/test-ObtainArraySpectra.R
+++ b/tests/testthat/test-ObtainArraySpectra.R
@@ -6,6 +6,9 @@ test_that("obtaining the array spectra works", {
   expect_error(ObtainArraySpectra(1), m, fixed = TRUE)
   expect_error(ObtainArraySpectra(matrix(1 : 6, 2, 3)), m, fixed = TRUE)
 
+  m <- "Only one proxy record (`cores` is of length 1)."
+  expect_error(ObtainArraySpectra(list(a = 1 : 10)), m, fixed = TRUE)
+
   m <- "Elements of `cores` must all have the same length."
   expect_error(ObtainArraySpectra(list(a = 1, b = 1 : 10, c = c(3, 8, 5))),
                                   m, fixed = TRUE)

--- a/tests/testthat/test-ObtainArraySpectra.R
+++ b/tests/testthat/test-ObtainArraySpectra.R
@@ -22,7 +22,8 @@ test_that("obtaining the array spectra works", {
   mean <- MeanSpectrum(single)
   stack <- SpecMTM(stats::ts(rowMeans(simplify2array(cores))))
 
-  expected <- list(N = 3, single = single, mean = mean, stack = stack)
+  expected <- list(single = single, mean = mean, stack = stack)
+  attr(expected, "array.par") <- c(nc = 3, nt = 100, res = 1)
   actual <- ObtainArraySpectra(cores)
 
   expect_equal(actual, expected)
@@ -35,7 +36,8 @@ test_that("obtaining the array spectra works", {
   mean <- MeanSpectrum(single)
   stack <- SpecMTM(stats::ts(rowMeans(simplify2array(cores)), deltat = 5))
 
-  expected <- list(N = 3, single = single, mean = mean, stack = stack)
+  expected <- list(single = single, mean = mean, stack = stack)
+  attr(expected, "array.par") <- c(nc = 3, nt = 100, res = 5)
   actual <- ObtainArraySpectra(cores, res = 5)
 
   expect_equal(actual, expected)
@@ -43,7 +45,8 @@ test_that("obtaining the array spectra works", {
   # effective number of records is set
 
   neff <- 1.5
-  expected <- list(N = neff, single = single, mean = mean, stack = stack)
+  expected <- list(single = single, mean = mean, stack = stack)
+  attr(expected, "array.par") <- c(nc = neff, nt = 100, res = 5)
   actual <- ObtainArraySpectra(cores, res = 5, neff = neff)
 
   expect_equal(actual, expected)

--- a/tests/testthat/test-SeparateSignalFromNoise.R
+++ b/tests/testthat/test-SeparateSignalFromNoise.R
@@ -29,35 +29,43 @@ test_that("SeparateSignalFromNoise error checks work", {
   expect_error(SeparateSignalFromNoise(list(mean = wrong_freq, stack = stack)),
                m, fixed = TRUE)
 
-  m <- "Supply (effective) number of records."
-  expect_error(SeparateSignalFromNoise(list(mean = mean, stack = stack)),
-               m, fixed = TRUE)
+  # --- test input checks related to attribute setting and neff ----------------
+
+  spectra <- list(mean = mean, stack = stack)
+
+  m <- "Attribute `array.par` missing from input object `spectra`."
+  expect_error(SeparateSignalFromNoise(spectra), m, fixed = TRUE)
+
+  attr(spectra, "array.par") <- c(nc = 10, nt = 100, res = 1)
+
+  m <- "Manually supplied `neff` must be a single integer >= 2."
+  expect_error(SeparateSignalFromNoise(spectra, neff = 1 : 10), m, fixed = TRUE)
+  expect_error(SeparateSignalFromNoise(spectra, neff = 0), m, fixed = TRUE)
 
   # --- test input checks related to measurement noise -------------------------
 
   m <- paste("`measurement.noise` must be a single value or a spectral object.")
   measurement.noise <- rnorm(3)
-  expect_error(SeparateSignalFromNoise(list(mean = mean, stack = stack, N = 1),
+  expect_error(SeparateSignalFromNoise(spectra, neff = 2,
                                        measurement.noise = measurement.noise),
                m, fixed = TRUE)
 
   # should also work with length-1 array
   measurement.noise <- matrix(0.1, 1, 1)
   expect_no_warning(SeparateSignalFromNoise(
-    list(mean = mean, stack = stack, N = 1),
-    measurement.noise = measurement.noise))
+    spectra, neff = 2, measurement.noise = measurement.noise))
 
   m <- paste("`measurement.noise` must be a list with elements",
              "`freq` and `spec` of equal length.")
   measurement.noise <- list(a = 1)
-  expect_error(SeparateSignalFromNoise(list(mean = mean, stack = stack, N = 1),
+  expect_error(SeparateSignalFromNoise(spectra, neff = 2,
                                        measurement.noise = measurement.noise),
                m, fixed = TRUE)
 
   m <- paste("No sufficient frequency axis overlap between proxy data",
              "and measurement noise spectrum.")
   measurement.noise <- list(freq = 0.5, spec = 0.1)
-  expect_error(SeparateSignalFromNoise(list(mean = mean, stack = stack, N = 1),
+  expect_error(SeparateSignalFromNoise(spectra, neff = 2,
                                        measurement.noise = measurement.noise),
                m, fixed = TRUE)
 
@@ -66,24 +74,24 @@ test_that("SeparateSignalFromNoise error checks work", {
   m <- paste("`diffusion` must be a list with elements",
              "`freq` and `spec` of equal length.")
   tf <- list(a = 1)
-  expect_error(SeparateSignalFromNoise(list(mean = mean, stack = stack, N = 1),
+  expect_error(SeparateSignalFromNoise(spectra, neff = 2,
                                        diffusion = tf), m, fixed = TRUE)
   tf <- list(freq = 1, spec = 1 : 5)
-  expect_error(SeparateSignalFromNoise(list(mean = mean, stack = stack, N = 1),
+  expect_error(SeparateSignalFromNoise(spectra, neff = 2,
                                        diffusion = tf), m, fixed = TRUE)
   m <- paste("`time.uncertainty` must be a list with elements",
              "`freq` and `spec` of equal length.")
-  expect_error(SeparateSignalFromNoise(list(mean = mean, stack = stack, N = 1),
+  expect_error(SeparateSignalFromNoise(spectra, neff = 2,
                                        time.uncertainty = tf), m, fixed = TRUE)
 
   tf <- list(freq = 1 : 5, spec = 1 : 5)
   m <- paste("No sufficient frequency axis overlap between proxy data",
              "and diffusion transfer function.")
-  expect_error(SeparateSignalFromNoise(list(mean = mean, stack = stack, N = 1),
+  expect_error(SeparateSignalFromNoise(spectra, neff = 2,
                                        diffusion = tf), m, fixed = TRUE)
   m <- paste("No sufficient frequency axis overlap between proxy data",
              "and time uncertainty transfer function.")
-  expect_error(SeparateSignalFromNoise(list(mean = mean, stack = stack, N = 1),
+  expect_error(SeparateSignalFromNoise(spectra, neff = 2,
                                        time.uncertainty = tf), m, fixed = TRUE)
 
 })
@@ -101,16 +109,23 @@ test_that("SeparateSignalFromNoise calculations work", {
   mean <- list(freq = signal$freq, spec = signal$spec + noise$spec)
   stack <- list(freq = signal$freq, spec = signal$spec + noise$spec / n)
 
-  actual <- SeparateSignalFromNoise(spectra = list(mean = mean, stack = stack),
-                                    neff = n)
-  expected <- list(N = n, signal = signal, noise = noise, snr = snr)
+  expected <- list(signal = signal, noise = noise, snr = snr)
+  a <- c(nc = n, nt = 10, res = 1)
+  attr(expected, "array.par") <- a
 
+  # with neff manually set
+  spectra <- list(mean = mean, stack = stack)
+  attr(spectra, "array.par") <- a
+  actual <- SeparateSignalFromNoise(spectra, neff = n)
+  expect_equal(actual, expected)
+
+  # with neff from attribute
+  actual <- SeparateSignalFromNoise(spectra)
   expect_equal(actual, expected)
 
   # --- test deprecated function name ------------------------------------------
 
-  expect_warning(actual <- SeparateSpectra(spectra = list(mean = mean, stack = stack),
-                                           neff = n))
+  expect_warning(actual <- SeparateSpectra(spectra, neff = n))
   expect_equal(actual, expected)
 
   # --- test including N and transfer function input ---------------------------
@@ -122,12 +137,14 @@ test_that("SeparateSignalFromNoise calculations work", {
                spec = diff$spec * (signal$spec + noise$spec))
   stack <- list(freq = signal$freq,
                 spec = diff$spec * (tunc$spec * signal$spec + noise$spec / n))
+  spectra = list(mean = mean, stack = stack)
+  attr(spectra, "array.par") <- a
 
-  actual <- SeparateSignalFromNoise(
-    spectra = list(mean = mean, stack = stack, N = n),
-    diffusion = diff,
-    time.uncertainty = tunc)
-  expected <- list(N = n, signal = signal, noise = noise, snr = snr)
+  actual <- SeparateSignalFromNoise(spectra,
+                                    diffusion = diff,
+                                    time.uncertainty = tunc)
+  expected <- list(signal = signal, noise = noise, snr = snr)
+  attr(expected, "array.par") <- a
 
   expect_equal(actual, expected)
 
@@ -176,7 +193,6 @@ test_that("SeparateSignalFromNoise calculations work", {
   snr <- list(freq = 1 : 10, spec = signal$spec / noise$spec)
   class(signal) <- class(noise) <- class(snr) <- "spec"
 
-  n <- 5
   mean <- list(freq = signal$freq,
                spec = signal$spec + noise$spec + measurement_noise_psd)
   stack <- list(freq = signal$freq,
@@ -184,10 +200,14 @@ test_that("SeparateSignalFromNoise calculations work", {
 
   # measurement noise variance
   measurement_noise_var <- 2 * max(signal$freq) * measurement_noise_psd
-  actual <- SeparateSignalFromNoise(spectra = list(mean = mean, stack = stack),
-                                    neff = n,
+  spectra <- list(mean = mean, stack = stack)
+  attr(spectra, "array.par") <- a
+
+  actual <- SeparateSignalFromNoise(spectra,
                                     measurement.noise = measurement_noise_var)
-  expected <- list(N = n, signal = signal, noise = noise, snr = snr)
+
+  expected <- list(signal = signal, noise = noise, snr = snr)
+  attr(expected, "array.par") <- a
 
   expect_equal(actual, expected)
 
@@ -196,8 +216,8 @@ test_that("SeparateSignalFromNoise calculations work", {
   measurement_noise <- list(freq = c(0.5, 3, 8, 15),
                             spec = rep(measurement_noise_psd, 4))
 
-  actual <- SeparateSignalFromNoise(spectra = list(mean = mean, stack = stack),
-                                    neff = n, measurement.noise = measurement_noise)
+  actual <- SeparateSignalFromNoise(spectra,
+                                    measurement.noise = measurement_noise)
 
   expect_equal(actual, expected)
 

--- a/tests/testthat/test-WrapSpectralResults.R
+++ b/tests/testthat/test-WrapSpectralResults.R
@@ -43,14 +43,21 @@ test_that("WrapSpectralResults works", {
   expect_equal(length(names(spec)), 0)
 
   expect_equal(sapply(spec, names), rep("raw", 3))
-  expect_equal(names(spec[[1]]$raw), c("N", "signal", "noise", "snr", "f.cutoff"))
-  expect_equal(names(spec[[2]]$raw), c("N", "signal", "noise", "snr", "f.cutoff"))
-  expect_equal(names(spec[[3]]$raw), c("N", "signal", "noise", "snr", "f.cutoff"))
+  expect_equal(names(spec[[1]]$raw), c("signal", "noise", "snr", "f.cutoff"))
+  expect_equal(names(spec[[2]]$raw), c("signal", "noise", "snr", "f.cutoff"))
+  expect_equal(names(spec[[3]]$raw), c("signal", "noise", "snr", "f.cutoff"))
 
   expect_true(is.spectrum(spec[[1]]$raw$signal))
   expect_true(is.spectrum(spec[[1]]$raw$noise))
   expect_true(is.spectrum(spec[[1]]$raw$snr))
   expect_true(is.na(spec[[1]]$raw$f.cutoff))
+
+  expect_equal(attr(spec[[1]]$raw, "array.par"),
+               c(nc = nc[1], nt = nt[1], res = 1))
+  expect_equal(attr(spec[[2]]$raw, "array.par"),
+               c(nc = nc[2], nt = nt[2], res = 1))
+  expect_equal(attr(spec[[3]]$raw, "array.par"),
+               c(nc = nc[3], nt = nt[3], res = 1))
 
   # test with correction functions applied to one or to both datasets
 

--- a/tests/testthat/test-paper-plotting.R
+++ b/tests/testthat/test-paper-plotting.R
@@ -28,9 +28,13 @@ test_that("paper plotting functions work", {
   m <- "No version `raw` available for dataset `wais`."
   expect_error(PublicationSNR(corrupted_data, data = "raw"), m, fixed = TRUE)
 
+  expect_no_error(s <- proxysnr:::PublicationSNR(data))
+  expect_equal(attr(s$dml, "array.par"), c(nc = 3, nt = 995, res = 1))
+  expect_equal(attr(s$wais, "array.par"), c(nc = 5, nt = 201, res = 1))
+
   expect_no_error(
     # suppress warnings from permil sign conversion failures
-    suppressWarnings(muench_laepple_fig05(proxysnr:::PublicationSNR(data)))
+    suppressWarnings(muench_laepple_fig05(s))
   )
 
 })

--- a/tests/testthat/test-plotting.R
+++ b/tests/testthat/test-plotting.R
@@ -34,10 +34,14 @@ test_that("plotting array spectra works", {
 
   single <- list(a = list(freq = 1 : 10, spec = 1 : 10), b = "ufp",
                  c = list(freq = 1 : 10, spec = 1 : 10))
+  spec <- list(single = single, mean = mean, stack = stack)
+
+  m <- "Attribute `array.par` missing from input object `spec`."
+  expect_error(PlotArraySpectra(spec), m, fixed = TRUE)
+
+  attr(spec, "array.par") <- c(nc = 3, nt = 10, res = 1)
   m <- "Cannot plot `spec$single[[2]]`: no spectral object."
-  expect_error(
-    PlotArraySpectra(list(single = single, mean = mean, stack = stack)),
-    m, fixed = TRUE)
+  expect_error(PlotArraySpectra(spec), m, fixed = TRUE)
 
   # create artificial data
   nc <- 5

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -168,3 +168,48 @@ test_that("interpolating spectra works", {
   expect_equal(actual$spec, expected$spec)
 
 })
+
+test_that("checking for array.par attribute works", {
+
+  m <- "Attribute `array.par` missing from input object `spectra`."
+
+  spectra  <- 1
+  expect_error(has.array.attribute(spectra), m, fixed = TRUE)
+  attr(spectra, "array.foo") <- "bar"
+  expect_error(has.array.attribute(spectra), m, fixed = TRUE)
+
+  m <- paste("Attribute `array.par` must a named vector",
+             "with elements `nc`, `nt`, `res`.")
+
+  attr(spectra, "array.par") <- "bar"
+  expect_error(has.array.attribute(spectra), m, fixed = TRUE)
+  attr(spectra, "array.par") <- c(nt = 10)
+  expect_error(has.array.attribute(spectra), m, fixed = TRUE)
+  attr(spectra, "array.par") <- c(nc = 10, res = 1)
+  expect_error(has.array.attribute(spectra), m, fixed = TRUE)
+
+  m <- paste("Element `nc` of `array.par attribute",
+             "(number of proxy records) must be a single integer >= 2.")
+  attr(spectra, "array.par") <- c(nc = 0, nt = 100, res = 1)
+  expect_error(has.array.attribute(spectra), m, fixed = TRUE)
+
+  m <- paste("Element `nt` of `array.par attribute",
+             "(number of observations per proxy record)",
+             "must be a single integer > 8.")
+  attr(spectra, "array.par") <- c(nc = 5, nt = 5, res = 1)
+  expect_error(has.array.attribute(spectra), m, fixed = TRUE)
+  attr(spectra, "array.par") <- c(nc = 5, nt = Inf, res = 1)
+  expect_error(has.array.attribute(spectra), m, fixed = TRUE)
+
+  m <- paste("Element `res` of `array.par attribute",
+             "(resolution of proxy records)",
+             "must be a single integer > 0.")
+  attr(spectra, "array.par") <- c(nc = 5, nt = 100, res = 0)
+  expect_error(has.array.attribute(spectra), m, fixed = TRUE)
+  attr(spectra, "array.par") <- c(nc = 5, nt = 100, res = NA)
+  expect_error(has.array.attribute(spectra), m, fixed = TRUE)
+
+  attr(spectra, "array.par") <- c(nc = 5, nt = 100, res = 1)
+  expect_no_error(has.array.attribute(spectra))
+
+})


### PR DESCRIPTION
For the creation of surrogate records to estimate confidence intervals (via `EstimateCI` and its auxiliary functions) information on the original proxy record array are needed, namely the number of proxy records, the number of observations (e.g. time steps) and the (time) resolution. 

Since it is **not** possible to uniquely and correctly reconstruct these data from the spectra obtained from `ObtainArraySpectra` or `SeparateSignalFromNoise` (erroneosly attempted before in 54afa03 together with 6f69223), the required information are now set as an attribute to the output list from `ObtainArraySpectra` and then consistently used throughout the functions `SeparateSignalFromNoise` and `EstimateCI` (and also in other pkg functions which are not related to the CI estimation).

This PR adds all relevant code and documentation changes and the required unit test updates.