### PR TITLE
MeanSpectrum: Allow length 1 list input and add more error checks.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: proxysnr
 Title: Separate Signal and Noise in Climate Proxy Records
-Version: 1.0.0
+Version: 1.0.1
 Authors@R: c(
     person("Thomas", "Münch", email = "thomas.muench@awi.de",
            role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# proxysnr 1.0.1
+
+* Fix error check in `MeanSpectrum()` function so that also lists of length 1
+  can be passed safely to the function.
+* Add additional checks in `MeanSpectrum()` to cover other possible input errors.
+
 # proxysnr 1.0.0
 
 ## Breaking changes

--- a/R/spec-utils.R
+++ b/R/spec-utils.R
@@ -171,7 +171,7 @@ SpecMTM <- function(timeSeries, k = 3, nw = 2, nFFT = "default",
 MeanSpectrum <- function(speclist) {
 
   # check for equal lengths of supplied spectra
-  if (stats::var(lengths(lapply(speclist, "[[", "freq"))) > 0)
+  if (length(speclist) > 1 & stats::var(lengths(lapply(speclist, "[[", "freq"))) > 0)
     stop("MeanSpectrum: Spectra are of different lengths.", call. = FALSE)
   
   mean <- list()

--- a/R/spec-utils.R
+++ b/R/spec-utils.R
@@ -170,6 +170,17 @@ SpecMTM <- function(timeSeries, k = 3, nw = 2, nFFT = "default",
 #'
 MeanSpectrum <- function(speclist) {
 
+  if (!is.list(speclist))
+    stop("MeanSpectrum: `speclist` must be a list.")
+  if (length(speclist) == 0)
+    stop("MeanSpectrum: `speclist` is of length 0.", call. = FALSE)
+
+  # check validity of list elements
+  if (!all(sapply(speclist, is.spectrum, USE.NAMES = FALSE)))
+    stop("MeanSpectrum: All `speclist` elements must be spectral objects ",
+         "(lists with elements `freq` and `spec` of equal length).",
+         call. = FALSE)
+
   # check for equal lengths of supplied spectra
   if (length(speclist) > 1 &
       stats::var(lengths(lapply(speclist, "[[", "freq"))) > 0) {

--- a/R/spec-utils.R
+++ b/R/spec-utils.R
@@ -171,8 +171,10 @@ SpecMTM <- function(timeSeries, k = 3, nw = 2, nFFT = "default",
 MeanSpectrum <- function(speclist) {
 
   # check for equal lengths of supplied spectra
-  if (length(speclist) > 1 & stats::var(lengths(lapply(speclist, "[[", "freq"))) > 0)
+  if (length(speclist) > 1 &
+      stats::var(lengths(lapply(speclist, "[[", "freq"))) > 0) {
     stop("MeanSpectrum: Spectra are of different lengths.", call. = FALSE)
+  }
   
   mean <- list()
   mean$freq <- speclist[[1]]$freq

--- a/tests/testthat/test-spec-utils.R
+++ b/tests/testthat/test-spec-utils.R
@@ -43,6 +43,7 @@ test_that("averaging spectra works", {
   s2 <- SpecMTM(stats::ts(rnorm(1000)))
   s3 <- SpecMTM(stats::ts(rnorm(1000)))
 
+  expect_no_error(MeanSpectrum(list(s1)))
   expect_error(MeanSpectrum(list(s1, s2, s3)), m, fixed = TRUE)
 
   s1 <- SpecMTM(stats::ts(rnorm(1000)))

--- a/tests/testthat/test-spec-utils.R
+++ b/tests/testthat/test-spec-utils.R
@@ -38,12 +38,25 @@ test_that("log-smoothing works", {
 
 test_that("averaging spectra works", {
 
-  m <- "MeanSpectrum: Spectra are of different lengths."
+  m <- "MeanSpectrum: `speclist` must be a list."
+  expect_error(MeanSpectrum(1), m, fixed = TRUE)
+  expect_error(MeanSpectrum(matrix(nrow = 4, ncol = 4)), m, fixed = TRUE)
+
+  m <- "MeanSpectrum: `speclist` is of length 0."
+  expect_error(MeanSpectrum(list()), m, fixed = TRUE)
+
   s1 <- SpecMTM(stats::ts(rnorm(100)))
   s2 <- SpecMTM(stats::ts(rnorm(1000)))
   s3 <- SpecMTM(stats::ts(rnorm(1000)))
 
   expect_no_error(MeanSpectrum(list(s1)))
+
+  m <- paste("MeanSpectrum: All `speclist` elements must be spectral objects",
+             "(lists with elements `freq` and `spec` of equal length).")
+  expect_error(MeanSpectrum(list(s1, 1 : 100, s2)), m, fixed = TRUE)
+  expect_error(MeanSpectrum(list(s1, list(freq = 1 : 100))), m, fixed = TRUE)
+
+  m <- "MeanSpectrum: Spectra are of different lengths."
   expect_error(MeanSpectrum(list(s1, s2, s3)), m, fixed = TRUE)
 
   s1 <- SpecMTM(stats::ts(rnorm(1000)))


### PR DESCRIPTION
This PR allows estimation of counting error transfer functions for single stacks of records. 

This required modifying MeanSpectrum to accept lists of length 1.